### PR TITLE
feat: Implement web GUI for device settings

### DIFF
--- a/light-controller/data/settings.html
+++ b/light-controller/data/settings.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Device Settings</title>
+    <style>
+        body { font-family: sans-serif; display: flex; flex-direction: column; align-items: center; }
+        label { margin-top: 10px; }
+        input { margin-bottom: 10px; width: 200px; padding: 5px; }
+        button { padding: 10px 20px; background-color: #007bff; color: white; border: none; cursor: pointer; }
+    </style>
+</head>
+<body>
+    <h1>Device Settings</h1>
+    <form action="/settings" method="POST">
+        <label for="timeout">Inactivity Timeout (seconds):</label><br>
+        <input type="number" id="timeout" name="timeout"><br>
+
+        <label for="timer_steps">Timer Steps:</label><br>
+        <input type="number" id="timer_steps" name="timer_steps"><br>
+
+        <label for="led_brightness">LED Ring Brightness (0-255):</label><br>
+        <input type="number" id="led_brightness" name="led_brightness" min="0" max="255"><br>
+
+        <button type="submit">Save Settings</button>
+    </form>
+</body>
+</html>

--- a/light-controller/light-controller.ino
+++ b/light-controller/light-controller.ino
@@ -2,11 +2,22 @@
   ESP32 → Rotary-only Tapo Dimmer
   Hamish Burke – May 2025
 ────────────────────────────────────────────────────────*/
+#include <ESPAsyncWebServer.h>
+#include <AsyncTCP.h>
 #include <WiFi.h>
+#include <SPIFFS.h>
 #include "tapo_device.h"
 #include <AiEsp32RotaryEncoder.h>
 #include "env.h"
+#include <EEPROM.h>
 
+// EEPROM Settings
+#define EEPROM_SIZE 64 // Allocate enough space for settings
+#define ADDR_TIMEOUT 0
+#define ADDR_TIMER_STEPS (ADDR_TIMEOUT + sizeof(unsigned long))
+#define ADDR_LED_BRIGHTNESS (ADDR_TIMER_STEPS + sizeof(int))
+#define ADDR_MAGIC_NUMBER (ADDR_LED_BRIGHTNESS + sizeof(uint8_t))
+#define CURRENT_MAGIC_NUMBER 0xAB
 
 /* Bulbs */
 struct Bulb { String ip; TapoDevice dev; };
@@ -15,6 +26,13 @@ Bulb bulbs[] = {
   { "192.168.1.225", TapoDevice() }
 };
 constexpr uint8_t NUM_BULBS = sizeof(bulbs) / sizeof(bulbs[0]);
+
+/* Web UI Settings */
+unsigned long inactivityTimeout = 5 * 60 * 1000; // 5 minutes in milliseconds
+int timerSteps = 5; // Brightness adjustment step for timer-based changes
+uint8_t ledRingBrightness = 100; // 0-255
+
+AsyncWebServer server(80);
 
 /* Pins */
 #define PIN_A  18
@@ -27,6 +45,37 @@ AiEsp32RotaryEncoder enc(PIN_A, PIN_B, PIN_SW, -1);
 bool allOn = false;
 uint8_t brightness = 50;
 volatile long prevVal = -1;
+unsigned long lastActivityTime = 0;
+
+/* EEPROM Functions */
+void saveSettings() {
+    Serial.println("Saving settings to EEPROM...");
+    EEPROM.put(ADDR_TIMEOUT, inactivityTimeout);
+    EEPROM.put(ADDR_TIMER_STEPS, timerSteps);
+    EEPROM.put(ADDR_LED_BRIGHTNESS, ledRingBrightness);
+    EEPROM.put(ADDR_MAGIC_NUMBER, (uint8_t)CURRENT_MAGIC_NUMBER); // Write magic number
+    EEPROM.commit();
+    Serial.println("Settings saved.");
+}
+
+void loadSettings() {
+    Serial.println("Loading settings from EEPROM...");
+    uint8_t magic;
+    EEPROM.get(ADDR_MAGIC_NUMBER, magic);
+
+    if (magic == CURRENT_MAGIC_NUMBER) { // Check if EEPROM data is valid
+        EEPROM.get(ADDR_TIMEOUT, inactivityTimeout);
+        EEPROM.get(ADDR_TIMER_STEPS, timerSteps);
+        EEPROM.get(ADDR_LED_BRIGHTNESS, ledRingBrightness);
+        Serial.println("Settings loaded successfully.");
+    } else {
+        Serial.println("No valid settings found in EEPROM, using default values.");
+        // Optional: save default values to EEPROM now
+        // saveSettings();
+    }
+    // Ensure loaded values are applied
+    enc.setStepValue(timerSteps);
+}
 
 /* Helpers */
 void connectWiFi() {
@@ -45,6 +94,9 @@ void setAllBrightness(uint8_t level) {
 void toggleAll() {
   allOn = !allOn;
   for (auto& b : bulbs) allOn ? b.dev.on() : b.dev.off();
+  if (allOn) {
+    lastActivityTime = millis(); // Reset inactivity timer when lights are turned on
+  }
 }
 
 /* ISR */
@@ -52,6 +104,9 @@ void IRAM_ATTR readISR() { enc.readEncoder_ISR(); }
 
 void setup() {
   Serial.begin(115200);
+  EEPROM.begin(EEPROM_SIZE);
+  loadSettings(); // Load settings from EEPROM
+
   connectWiFi();
   loginAll();
 
@@ -62,17 +117,86 @@ void setup() {
   attachInterrupt(digitalPinToInterrupt(PIN_A), readISR, CHANGE);
   attachInterrupt(digitalPinToInterrupt(PIN_B), readISR, CHANGE);
 
+  SPIFFS.begin(true);
+  server.begin();
+
+  // Serve settings.html
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
+    request->send(SPIFFS, "/settings.html", String(), false);
+  });
+
+  // Handle settings update
+  server.on("/settings", HTTP_POST, [](AsyncWebServerRequest *request){
+    String message = "Settings updated successfully!";
+    bool error = false;
+
+    if (request->hasParam("timeout", true)) {
+        inactivityTimeout = request->getParam("timeout", true)->value().toInt() * 1000; // Convert s to ms
+    } else {
+        message = "Error: Timeout parameter missing.";
+        error = true;
+    }
+
+    if (request->hasParam("timer_steps", true)) {
+        timerSteps = request->getParam("timer_steps", true)->value().toInt();
+    } else {
+        message = "Error: Timer Steps parameter missing.";
+        error = true;
+    }
+
+    if (request->hasParam("led_brightness", true)) {
+        ledRingBrightness = request->getParam("led_brightness", true)->value().toInt();
+    } else {
+        message = "Error: LED Brightness parameter missing.";
+        error = true;
+    }
+
+    if (error) {
+        request->send(400, "text/plain", message);
+    } else {
+        enc.setStepValue(timerSteps); // Apply timer steps setting before saving
+        saveSettings(); // Save the updated settings
+        request->send(200, "text/plain", message + "\nRedirecting back in 2 seconds...");
+        // It would be better to redirect properly, but for simplicity:
+        // request->redirect("/"); // This might not work as expected without more complex JS on client
+    }
+  });
+
   enc.setBoundaries(1, 100, false);
-  enc.setEncoderValue(brightness);
+  enc.setEncoderValue(brightness); // Brightness is not saved/loaded yet, uses default
+  // enc.setStepValue(timerSteps); // This is now called within loadSettings()
+  lastActivityTime = millis(); // Initialize activity time after settings are potentially loaded
 }
 
 void loop() {
+  // Inactivity check
+  if (allOn && (millis() - lastActivityTime > inactivityTimeout)) {
+    toggleAll(); // Turn off lights
+    Serial.println("Inactivity timeout reached. Turning off lights.");
+  }
+
+  // TODO: Implement LED ring brightness control using ledRingBrightness variable
+
   long v = enc.readEncoder();
   if (v != prevVal) {
+    lastActivityTime = millis(); // Update activity time on encoder change
     prevVal = v;
     brightness = static_cast<uint8_t>(v);
-    if (!allOn) toggleAll();
+    if (!allOn) {
+      toggleAll();
+    }
     setAllBrightness(brightness);
   }
-  if (enc.isEncoderButtonClicked()) toggleAll();
+
+  if (enc.isEncoderButtonClicked()) {
+    // lastActivityTime is updated by toggleAll() if it turns lights on,
+    // or we can set it explicitly if lights were already on.
+    // For simplicity, toggleAll() handles it if lights turn on.
+    // If lights are turned off, lastActivityTime is not critical for the *next* timeout period.
+    // If lights were already on and are toggled (which is rare for a simple click),
+    // toggleAll will update it.
+    // Explicitly setting it here ensures it's always updated on a click.
+    lastActivityTime = millis();
+    toggleAll();
+  }
 }


### PR DESCRIPTION
This commit introduces a local web GUI hosted on the ESP32 for configuring various device settings.

Key features:
- Web interface accessible via the ESP32's IP address.
- Configuration options for:
    - Inactivity Timeout (seconds): Automatically turns off lights after a set period of inactivity.
    - Timer Steps: Adjusts the sensitivity of the rotary encoder for brightness control.
    - LED Ring Brightness (0-255): Placeholder for future LED ring control.
- Settings are saved to EEPROM and loaded on startup, persisting across reboots.
- SPIFFS is used to store and serve the HTML settings page.

The implementation includes:
- ESPAsyncWebServer and AsyncTCP libraries for handling HTTP requests.
- HTML page (`settings.html`) for the user interface.
- Request handlers for serving the HTML and processing settings updates.
- Integration of new settings into the existing device logic.
- EEPROM functionality for persistent storage of settings.