### PR TITLE
Fix: Install ESPAsyncWebServer and AsyncTCP libraries in CI

### DIFF
--- a/.github/workflows/compile_firmware.yml
+++ b/.github/workflows/compile_firmware.yml
@@ -20,6 +20,8 @@ jobs:
           arduino-cli config init
           arduino-cli core update-index
           arduino-cli core install esp32:esp32
+          arduino-cli lib install "ESPAsyncWebServer"
+          arduino-cli lib install "AsyncTCP"
           # Add any library installations here if needed, e.g.:
           # arduino-cli lib install "Some Library"
 


### PR DESCRIPTION
The Arduino compilation was failing in the GitHub Actions workflow due to the missing ESPAsyncWebServer.h header file.

This commit updates the .github/workflows/compile_firmware.yml file to explicitly install ESPAsyncWebServer and its dependency, AsyncTCP, using the arduino-cli lib install command during the setup phase. This ensures the libraries are available before the compilation step.