### PR TITLE
Fix: Install all required Arduino libraries in CI

### DIFF
--- a/.github/workflows/compile_firmware.yml
+++ b/.github/workflows/compile_firmware.yml
@@ -23,6 +23,8 @@ jobs:
           arduino-cli lib install "ESPAsyncWebServer"
           arduino-cli lib install "AsyncTCP"
           arduino-cli lib install "ElegantOTA"
+          mkdir -p ~/Arduino/libraries
+          git clone https://github.com/Slaymish/tapo-esp32.git ~/Arduino/libraries/tapo-esp32
           # Add any library installations here if needed, e.g.:
           # arduino-cli lib install "Some Library"
 


### PR DESCRIPTION
The Arduino compilation was failing in the GitHub Actions workflow due to several missing header files: ESPAsyncWebServer.h, ElegantOTA.h, and the custom library tapo_device.h.

This commit updates the .github/workflows/compile_firmware.yml file to:
1. Install ESPAsyncWebServer and its dependency AsyncTCP using `arduino-cli lib install`.
2. Install ElegantOTA using `arduino-cli lib install`.
3. Clone the custom tapo-esp32 library from https://github.com/Slaymish/tapo-esp32.git into the `~/Arduino/libraries` directory.

These changes ensure all required libraries are available before the compilation step.