### PR TITLE
Fix: Generate env.h in workflow before compiling

### DIFF
--- a/.github/workflows/compile_firmware.yml
+++ b/.github/workflows/compile_firmware.yml
@@ -34,6 +34,11 @@ jobs:
           # Clone any custom libraries (e.g., Tapo API)
           git clone --depth 1 https://github.com/Slaymish/tapo-esp32.git ~/Arduino/libraries/tapo-esp32
 
+      - name: Generate env.h
+        run: |
+          chmod +x generate_env_header.sh
+          bash generate_env_header.sh
+
       - name: Compile Sketch
         run: |
           arduino-cli compile \


### PR DESCRIPTION
The arduino-cli compile step was failing because the `env.h` file was missing. This file is expected to be generated from `env.h.example`.

This commit updates the GitHub Actions workflow (`compile_firmware.yml`) to include a new step that runs the `generate_env_header.sh` script before the compilation step. This script copies `env.h.example` to `light-controller/env.h`, providing the necessary header file for the compilation to succeed. The script is also made executable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the workflow by adding an automated step to generate the environment header file before compiling firmware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->